### PR TITLE
Rename `generateField()` to `fieldAttributes()` method in `InputInterface::class`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
-# 0.1.1 Under development
+# 0.2.0 Under development
 
 - Enh #3: Implement interface `RenderInterface::class` (@terabytesoftw)
 - Enh #4: Add interface `ContentInterface::class` and `LabelInterface::class` (@terabytesoftw)
+- Enh #5: Rename `generateField()` to `fieldAttributes()` method in `InputInterface::class` (@terabytesoftw)
 
 ## 0.1.0 February 27, 2024
 

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -33,13 +33,13 @@ interface InputInterface extends RenderInterface
     /**
      * Generate the id and name attributes for the field.
      *
-     * @param string $modelName The name of the model.
-     * @param string $fieldName The name of the field.
+     * @param string $formModel The name of the model.
+     * @param string $property The name of the property.
      * @param bool $arrayable Whether the field is arrayable.
      *
      * @return static A new instance or clone of the current object with the id and name attributes set.
      */
-    public function generateField(string $modelName, string $fieldName, bool $arrayable = false): static;
+    public function fieldAttributes(string $formModel, string $property, bool $arrayable = false): static;
 
     /**
      * Set the ID of the widget.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
