### PR TITLE
Remove arrayable parameter in `fieldAttributes()` method in `InputInterface::class`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enh #3: Implement interface `RenderInterface::class` (@terabytesoftw)
 - Enh #4: Add interface `ContentInterface::class` and `LabelInterface::class` (@terabytesoftw)
 - Enh #5: Rename `generateField()` to `fieldAttributes()` method in `InputInterface::class` (@terabytesoftw)
+- Bug #6: Remove arrayable parameter in `fieldAttributes()` method in `InputInterface::class` (@terabytesoftw)
 
 ## 0.1.0 February 27, 2024
 

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -31,15 +31,14 @@ interface InputInterface extends RenderInterface
     public function class(string $value, bool $override = false): static;
 
     /**
-     * Generate the id and name attributes for the field.
+     * Generate the id and name attributes for the input field.
      *
-     * @param string $formModel The name of the model.
-     * @param string $property The name of the property.
-     * @param bool $arrayable Whether the field is arrayable.
+     * @param string $formModel The form model name.
+     * @param string $property The property name.
      *
      * @return static A new instance or clone of the current object with the id and name attributes set.
      */
-    public function fieldAttributes(string $formModel, string $property, bool $arrayable = false): static;
+    public function fieldAttributes(string $formModel, string $property): static;
 
     /**
      * Set the ID of the widget.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
