### PR TITLE
Rename `notLabel()` to `disableLabel()` method in `LabelInterface::class`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
-## 0.2.1 Under development
+## 0.3.0 Under development
+
+- Bug #7: Rename `notLabel()` to `disableLabel()` method in `LabelInterface::class` (@terabytesoftw)
 
 ## 0.2.0 February 29, 2024
 

--- a/src/LabelInterface.php
+++ b/src/LabelInterface.php
@@ -10,6 +10,13 @@ namespace PHPForge\Html\Interop;
 interface LabelInterface
 {
     /**
+     * Disable the label.
+     *
+     * @return static A new instance or clone of the current object with the label disabled.
+     */
+    public function disableLabel(): static;
+
+    /**
      * Set the current instance as being enclosed by a label.
      *
      * @param bool $value The value to set.
@@ -54,11 +61,4 @@ interface LabelInterface
      * @return static A new instance of the current class with the specified label `for` attribute.
      */
     public function labelFor(string|null $value): static;
-
-    /**
-     * Disable the label rendering.
-     *
-     * @return static A new instance of the current class with the label disabled.
-     */
-    public function notLabel(): static;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
